### PR TITLE
Add pre- and post-run callback support

### DIFF
--- a/jurigged/live.py
+++ b/jurigged/live.py
@@ -79,12 +79,7 @@ def conservative_logger(event):
 
 
 class Watcher:
-    def __init__(
-        self,
-        registry,
-        debounce=DEFAULT_DEBOUNCE,
-        poll=False
-    ):
+    def __init__(self, registry, debounce=DEFAULT_DEBOUNCE, poll=False):
         if poll:
             self.observer = PollingObserverVFS(
                 stat=os.stat, listdir=os.scandir, polling_interval=poll

--- a/jurigged/live.py
+++ b/jurigged/live.py
@@ -108,10 +108,10 @@ class Watcher:
         cf = self.registry.get(path)
         try:
             if self.prerun_callback:
-                self.prerun_callback()
+                self.prerun_callback(path, cf)
             cf.refresh()
             if self.postrun_callback:
-                self.postrun_callback()
+                self.postrun_callback(path, cf)
         except Exception as exc:
             self.registry.log(exc)
 

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -169,6 +169,7 @@ def test_prerun(tmod):
     )
     pre_watcher.prerun.register(prerun_test)
     za = tmod.imp("za", mangle=mangle)
+    assert za.word == "tyrant"
 
     tmod.write("za_8.py", 'word = "pirate"\n')
     time.sleep(0.05)
@@ -182,6 +183,7 @@ def test_prerun(tmod):
 
     pre_watcher.stop()
     pre_watcher.join()
+
 
 def test_postrun(tmod):
     test_var = 0
@@ -200,6 +202,7 @@ def test_postrun(tmod):
     )
     post_watcher.postrun.register(postrun_test)
     za = tmod.imp("za", mangle=mangle)
+    assert za.word == "tyrant"
 
     tmod.write("za_9.py", 'word = "tyrant"\n')
     time.sleep(0.05)
@@ -228,7 +231,7 @@ def test_prerun_postrun(tmod):
 
     mangle = "_10"
     registry = Registry()
-    
+
     both_watcher = watch(
         pattern=tmod.rel("*.py"),
         registry=registry,
@@ -238,6 +241,7 @@ def test_prerun_postrun(tmod):
     both_watcher.postrun.register(postrun_test)
 
     za = tmod.imp("za", mangle=mangle)
+    assert za.word == "tyrant"
 
     tmod.write("za_10.py", 'word = "pirate"\n')
     time.sleep(0.05)

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -170,8 +170,8 @@ def test_callback(tmod):
         pattern=tmod.rel("*.py"),
         registry=registry,
         debounce=0,
-        prerun_callback=prerun_test,
     )
+    pre_watcher.prerun.register(prerun_test)
     za = tmod.imp("za", mangle=mangle)
 
     tmod.write("za_8.py", 'word = "pirate"\n')
@@ -185,8 +185,8 @@ def test_callback(tmod):
         pattern=tmod.rel("*.py"),
         registry=registry,
         debounce=0,
-        postrun_callback=postrun_test,
     )
+    post_watcher.postrun.register(postrun_test)
 
     tmod.write("za_8.py", 'word = "tyrant"\n')
     time.sleep(0.05)
@@ -199,9 +199,9 @@ def test_callback(tmod):
         pattern=tmod.rel("*.py"),
         registry=registry,
         debounce=0,
-        prerun_callback=prerun_test,
-        postrun_callback=postrun_test,
     )
+    both_watcher.prerun.register(prerun_test)
+    both_watcher.postrun.register(postrun_test)
 
     tmod.write("za_8.py", 'word = "pirate"\n')
     time.sleep(0.05)

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -155,11 +155,11 @@ def test_poll(tmod):
 def test_callback(tmod):
     test_var = 0
 
-    def prerun_test():
+    def prerun_test(path, cf):
         nonlocal test_var
         test_var += 1
 
-    def postrun_test():
+    def postrun_test(path, cf):
         nonlocal test_var
         test_var += 2
 


### PR DESCRIPTION
As per #18 , this adds (basic) callback support for pre- and post-refresh. It doesn't pass in anything into the callbacks, but is meant to provide a basic means of adding this support.

If you have any suggestions for edits, please let me know and I'll get them made.