### PR TITLE
Multiple watch args, future annotations, pytest asserts, and some other patches

### DIFF
--- a/jurigged/codetools.py
+++ b/jurigged/codetools.py
@@ -1,9 +1,11 @@
+import __future__
+
 import ast
 import re
 from abc import abstractmethod
 from ast import _splitlines_no_ff as splitlines
 from collections import Counter
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from contextvars import ContextVar
 from dataclasses import dataclass, field, replace as dc_replace
 from types import CodeType, ModuleType
@@ -12,10 +14,12 @@ from typing import List, Optional, Union
 from codefind import ConformException, code_registry as codereg, conform
 from ovld import ovld
 
+from .config import CONFIG
 from .parse import Variables, variables
 from .utils import EventSource, shift_lineno
 
 current_info = ContextVar("current_info", default=None)
+_future_feature_names = set(__future__.all_feature_names)
 
 
 sep_at_start = re.compile(r"^ *[\n;]")
@@ -41,6 +45,27 @@ class attrproxy:
 
     def get(self, item, dflt):
         return getattr(self.cls, item, dflt)
+
+
+def _get_future_compiler_flags(glb) -> int:
+    """use future feature names to get any that are set in the global namespace
+
+    `or` these together to get the flags for the compile function
+    """
+    flags = 0
+    for key in glb.keys() & _future_feature_names:
+        with suppress(Exception):
+            flags |= glb[key].compiler_flag
+    return flags
+
+
+def _compile_with_flags(node, mode, filename, glb):
+    """compile the node with the future flags set in the global namespace
+
+    basically, respect `from __future__ import annotations`
+    """
+    flags = _get_future_compiler_flags(glb)
+    return compile(node, mode=mode, filename=filename, flags=flags)
 
 
 @dataclass
@@ -240,7 +265,9 @@ class Definition:
     def evaluate(self, glb, lcl):
         if self.node is not None:
             node = ast.Module(body=[self.node], type_ignores=[])
-            code = compile(node, mode="exec", filename=self.filename)
+            code = _compile_with_flags(
+                node, mode="exec", filename=self.filename, glb=glb
+            )
             code = code.replace(co_name="<adjust>")
             exec(code, glb, lcl)
             codereg.assimilate(
@@ -658,13 +685,30 @@ class FunctionDefinition(GroupDefinition):
     # Management #
     ##############
 
-    def stash(self, lineno=1, col_offset=0):
+    def _stash(self, lineno=1, col_offset=0):
+        # Original jurigged stash logic
+
         if not isinstance(self.parent, FunctionDefinition):
             co = self.get_object()
             if co and (delta := lineno - co.co_firstlineno):
                 self.recode(shift_lineno(co, delta), use_cache=False)
 
         return super().stash(lineno, col_offset)
+
+    def stash(self, lineno=1, col_offset=0):
+        # patch: There's an off-by-one bug coming from somewhere in jurigged.
+        #              This affects replaced functions. When line numbers are wrong
+        #              the debugger and inspection logic doesn't work as expected.
+        # TODO: We should fix this in jurigged itself, but porting over from here for now:
+        # https://github.com/breuleux/jurigged/issues/29
+        if not isinstance(self.parent, FunctionDefinition):
+            co = self.get_object()
+            if co and (delta := lineno - co.co_firstlineno):
+                delta -= 1  # fix off-by-one
+                if delta != 0:
+                    self.recode(shift_lineno(co, delta), use_cache=False)
+
+        return self._stash(lineno, col_offset)
 
     ##################
     # Correspondence #
@@ -732,7 +776,9 @@ class FunctionDefinition(GroupDefinition):
                 self._codeobj = codereg.codes[pth]
         return self._codeobj
 
-    def reevaluate(self, new_node, glb):
+    def _reevalute(self, new_node, glb):
+        # Original jurigged reevaluate logic
+
         ext = new_node.extent
         closure = False
         lcl = {}
@@ -785,7 +831,9 @@ class FunctionDefinition(GroupDefinition):
             node = ast.Module(body=[wrap], type_ignores=[])
         else:
             node = ast.Module(body=[new_node], type_ignores=[])
-        code = compile(node, mode="exec", filename=ext.filename)
+        code = _compile_with_flags(
+            node, mode="exec", filename=ext.filename, glb=glb
+        )
         code = code.replace(co_name="<adjust>")
         exec(code, glb, lcl)
         if closure:
@@ -801,6 +849,51 @@ class FunctionDefinition(GroupDefinition):
         conform(self.get_object(), new_obj)
         self._codeobj = new_obj.__code__
         return new_obj
+
+    def reevaluate(self, new_node, glb):
+        # patch: The assertion rewrite is from pytest. Jurigged doesn't
+        #              seem to have a way to add rewrite hooks
+        # TODO: We should fix this in jurigged itself, but porting over from here for now:
+        # https://github.com/breuleux/jurigged/issues/29
+        new_node = self.apply_assertion_rewrite(new_node, glb)
+        obj = self._reevalute(new_node, glb)
+
+        return obj
+
+    def apply_assertion_rewrite(self, ast_func, glb):
+        from _pytest.assertion.rewrite import AssertionRewriter
+
+        # We only want to apply assertion rewrites if we're running in a pytest context
+        if not CONFIG.rewrite_asserts_to_pytest_asserts:
+            return ast_func
+
+        nodes: list[ast.AST] = [ast_func]  # type: ignore
+        while nodes:
+            node = nodes.pop()
+            for name, f in ast.iter_fields(node):
+                if isinstance(f, list):
+                    new: list[ast.AST] = []  # type: ignore
+                    for i, child in enumerate(f):
+                        if isinstance(child, ast.Assert):
+                            # Transform assert.
+                            new.extend(
+                                AssertionRewriter(
+                                    glb["__file__"], None, None
+                                ).visit(child)
+                            )
+                        else:
+                            new.append(child)
+                            if isinstance(child, ast.AST):
+                                nodes.append(child)
+                    setattr(node, name, new)
+                elif (
+                    isinstance(f, ast.AST)
+                    # Don't recurse into expressions as they can't contain
+                    # asserts.
+                    and not isinstance(f, ast.expr)
+                ):
+                    nodes.append(f)
+        return ast_func
 
 
 @dataclass

--- a/jurigged/config.py
+++ b/jurigged/config.py
@@ -1,0 +1,2 @@
+class CONFIG:
+    rewrite_asserts_to_pytest_asserts = False

--- a/jurigged/live.py
+++ b/jurigged/live.py
@@ -250,6 +250,7 @@ def cli():  # pragma: no cover
         "--watch",
         "-w",
         metavar="PATH",
+        nargs="+",
         help="Wildcard path/directory for which files to watch",
     )
     parser.add_argument(

--- a/jurigged/utils.py
+++ b/jurigged/utils.py
@@ -24,17 +24,26 @@ class EventSource(list):
             self._history.append((args, kwargs))
 
 
-def glob_filter(pattern):
-    if pattern.startswith("~"):
-        pattern = os.path.expanduser(pattern)
-    elif not pattern.startswith("/"):
-        pattern = os.path.abspath(pattern)
+def glob_filter(patterns):
+    if isinstance(patterns, str):
+        patterns = [patterns]
 
-    if os.path.isdir(pattern):
-        pattern = os.path.join(pattern, "*")
+    final_patterns = []
+    for pattern in patterns:
+        if pattern.startswith("~"):
+            pattern = os.path.expanduser(pattern)
+        elif not pattern.startswith("/"):
+            pattern = os.path.abspath(pattern)
+
+        if os.path.isdir(pattern):
+            pattern = os.path.join(pattern, "*")
+
+        final_patterns.append(pattern)
 
     def matcher(filename):
-        return fnmatch.fnmatch(filename, pattern)
+        return any(
+            fnmatch.fnmatch(filename, pattern) for pattern in final_patterns
+        )
 
     return matcher
 

--- a/tests/snippets/asserts:main.py
+++ b/tests/snippets/asserts:main.py
@@ -1,0 +1,2 @@
+def foo():
+    assert 1 == 1

--- a/tests/snippets/asserts:new.py
+++ b/tests/snippets/asserts:new.py
@@ -1,0 +1,5 @@
+def foo():
+    assert 1 == 1
+    # adding a new assert - will be rewritten to pytest assert
+    x = 2
+    assert 1 == x

--- a/tests/snippets/future_flags:main.py
+++ b/tests/snippets/future_flags:main.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/tests/snippets/future_flags:name_collision.py
+++ b/tests/snippets/future_flags:name_collision.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+print_function = (
+    "this has the same name as a __future__ import but is not the right type"
+)
+
+
+def f(a: nonexistant_type) -> str:
+    return a

--- a/tests/snippets/future_flags:new.py
+++ b/tests/snippets/future_flags:new.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+
+def f(a: nonexistant_type) -> str:
+    return a

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -46,6 +46,9 @@ def test_glob_filter():
     assert glob_test("/a/b/*.py", "/a/b/hello.py")
     assert glob_test("/a/b/*.py", "/a/b/c/hello.py")
     assert not glob_test("/a/b/*.py", "/b/hello.py")
+    # Test multiple globs
+    assert glob_test(["/a/*", "/b/*"], "/a/foo.py")
+    assert glob_test(["/a/*", "/b/*"], "/b/foo.py")
 
 
 def test_registry_prepare(tmod):


### PR DESCRIPTION
This PR includes the following changes:
- Adds support for passing in multiple glob filters to the --watch arg
- Adds support for future compiler flags (also included by my coworker in this PR: https://github.com/breuleux/jurigged/pull/37)
- Adds support for optional patching asserts with pytest asserts for a better DX when using jurigged in a pytest context
- Pulls in a fix for an off by one error called out by @JamesHutchison here: https://github.com/breuleux/jurigged/issues/29

I'm happy to split these out into separate PRs or to refactor as necessary! Ideally we can find the root cause of the off by one error in the underlying codetools logic in jurigged rather than patching it retroactively.